### PR TITLE
new copybuilds script

### DIFF
--- a/copybuilds.sh
+++ b/copybuilds.sh
@@ -1,8 +1,30 @@
-# script to copy build files into one public-builds directory
+#!/usr/bin/env bash
+set -e
 
-mkdir -p publish-builds
-cp versions/1.19.2/build/libs/tt20-0.7.1.jar publish-builds/tt20-0.7.1+mc1.19.2.jar
-cp versions/1.20.1/build/libs/tt20-0.7.1.jar publish-builds/tt20-0.7.1+mc1.20.1.jar
-cp versions/1.20.6/build/libs/tt20-0.7.1.jar publish-builds/tt20-0.7.1+mc1.20.6.jar
-cp versions/1.21/build/libs/tt20-0.7.1.jar publish-builds/tt20-0.7.1+mc1.21.jar
-cp versions/1.21.5/build/libs/tt20-0.7.1.jar publish-builds/tt20-0.7.1+mc1.21.5.jar
+mod_id="$(grep -E '^mod_id=' gradle.properties | cut -d'=' -f2)"
+mod_version="$(grep -E '^mod_version=' gradle.properties | cut -d'=' -f2)"
+
+if [ -z "$mod_version" ]; then
+  echo "mod_version not found!"
+  exit 1
+fi
+
+echo "Found mod properties: $mod_id-$mod_version"
+
+out_dir="publish-builds"
+mkdir -p "$out_dir"
+
+for mcdir in versions/*; do
+  [ -d "$mcdir" ] || continue
+
+  mcver="$(basename "$mcdir")"
+  jar="$mcdir/build/libs/$mod_id-$mod_version.jar"
+  out="$out_dir/$mod_id-$mod_version+mc$mcver.jar"
+
+  if [ -f "$jar" ]; then
+    cp "$jar" "$out"
+    echo "Copied mc$mcver"
+  else
+    echo "Skipping mc$mcver (not found)"
+  fi
+done


### PR DESCRIPTION
This dynamically gets `mod_id` and `mod_version` in `gradle.properties` and then goes through every version in `versions` folder. So this thing is 100% automatic and doesn't need to be updated for new mod/mc versions :D